### PR TITLE
Make database packages extras and update poetry version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.local
-          key: poetry-1.1.12-0
+          key: poetry-1.2.0rc1
 
       # Install Poetry. You could do this manually, or there are several actions that do this.
       # `snok/install-poetry` seems to be minimal yet complete, and really just calls out to
@@ -75,7 +75,7 @@ jobs:
       # cache it.
       - uses: snok/install-poetry@v1
         with:
-          version: 1.1.12
+          version: 1.2.0rc1
           virtualenvs-create: true
           virtualenvs-in-project: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
       # Install dependencies. `--no-root` means "install all dependencies but not the project
       # itself", which is what you want to avoid caching _your_ code. The `if` statement
       # ensures this only runs on a cache miss.
-      - run: poetry install --no-interaction --no-root
+      - run: poetry install --no-interaction --no-root --all-extras
         if: steps.cache-deps.outputs.cache-hit != 'true'
 
       # Now install _your_ project. This isn't necessary for many types of projects -- particularly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
       # things like Django apps don't need this. But it's a good idea since it fully-exercises the
       # pyproject.toml and makes that if you add things like console-scripts at some point that
       # they'll be installed and working.
-      - run: poetry install --no-interaction
+      - run: poetry install --no-interaction --all-extras
 
       - name: Static typing with mypy
         run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,7 +71,7 @@ name = "cffi"
 version = "1.15.1"
 description = "Foreign Function Interface for Python calling C code."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -112,7 +112,7 @@ name = "cryptography"
 version = "37.0.4"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -131,7 +131,7 @@ name = "deprecated"
 version = "1.2.13"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
@@ -175,7 +175,7 @@ name = "importlib-metadata"
 version = "4.12.0"
 description = "Read metadata from Python packages"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -205,7 +205,7 @@ name = "jeepney"
 version = "0.8.0"
 description = "Low-level, pure Python DBus protocol wrapper."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.extras]
@@ -231,7 +231,7 @@ name = "keyring"
 version = "23.4.1"
 description = "Store and access your passwords safely."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -249,7 +249,7 @@ name = "keyrings.alt"
 version = "3.1"
 description = "Alternate keyring implementations"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7"
 
 [package.dependencies]
@@ -322,7 +322,7 @@ name = "mysqlclient"
 version = "2.1.1"
 description = "Python interface to MySQL"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [[package]]
@@ -432,7 +432,7 @@ name = "psycopg2"
 version = "2.9.5"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [[package]]
@@ -448,7 +448,7 @@ name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -553,7 +553,7 @@ name = "pywin32-ctypes"
 version = "0.2.0"
 description = ""
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -587,7 +587,7 @@ name = "secretstorage"
 version = "3.3.2"
 description = "Python bindings to FreeDesktop.org Secret Service API"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -664,7 +664,7 @@ name = "synapseclient"
 version = "2.7.0"
 description = "A client for Synapse, a collaborative compute space  that allows scientists to share and analyze data together."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7.*"
 
 [package.dependencies]
@@ -749,17 +749,22 @@ name = "zipp"
 version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.extras]
 docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+mysql = ["mysqlclient"]
+postgres = ["psycopg2"]
+synapse = ["synapseclient"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "59a8070b6c55b68fbbbe0255b53d5175f841060a14a6d318561c7bde6bf5ff45"
+content-hash = "b9a451044fe7ffe06aa776f19cf49384a4ca2328de9c2b827e194f75ce93f7b0"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ authors = ["andrewelamb <andrewelamb@gmail.com>"]
 python = "^3.9"
 SQLAlchemy = "^1.4.39"
 PyYAML = "^6.0"
-mysqlclient = "^2.1.1"
+mysqlclient = {version = "^2.1.1", optional = true}
 SQLAlchemy-Utils = "^0.38.3"
 requests = "^2.28.1"
-synapseclient = "^2.6.0"
+synapseclient = {version = "^2.6.0", optional = true}
 pandas = "^1.4.3"
 pdoc = "^12.1.0"
 black = "^22.6.0"
@@ -19,8 +19,13 @@ networkx = "^2.8.6"
 pylint = "^2.15.4"
 mypy = "^0.982"
 pytest-mock = "^3.10.0"
-psycopg2 = "^2.9.5"
+psycopg2 = {version = "^2.9.5", optional = true}
 tenacity = "^8.1.0"
+
+[tool.poetry.extras]
+mysql = ["mysqlclient"]
+postgres = ["psycopg2"]
+synapse = ["synapseclient"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Make database dependencies marked as `optional` and `extra` so that only the relevant packages need to be installed. This will allow the deployment of `schematic` containers containing `schematic-db` without requiring the other database packages to be installed at the OS level. For installing with the old behavior, the `--all-extras` flag should be added to `poetry install`.
This also updates poetry to be on par with `schematic`