### PR TITLE
added ManifestPrimaryKeyError

### DIFF
--- a/schematic_db/rdb_updater/rdb_updater.py
+++ b/schematic_db/rdb_updater/rdb_updater.py
@@ -43,15 +43,19 @@ class UpsertError(Exception):
 class ManifestPrimaryKeyError(Exception):
     """Raised when a manifest is missing its primary key"""
 
-    def __init__(self, table_name: str, primary_key: str, columns: list[str]) -> None:
+    def __init__(
+        self, table_name: str, dataset_id: str, primary_key: str, columns: list[str]
+    ) -> None:
         """
         Args:
-            table_name (str): The name of the table the upsert occurred in
-            primary_key (str): The dataset id of the manifest that was being upserted
+            table_name (str): The name of the table for which the manifest was downloaded
+            dataset_id (str): The dataset id of the manifest
+            primary_key (str): The primary key of the table
             columns (list[str]): The columns in the manifest
         """
         self.message = "Manifest is missing its primary key"
         self.table_name = table_name
+        self.dataset_id = dataset_id
         self.primary_key = primary_key
         self.columns = columns
         super().__init__(self.message)
@@ -60,6 +64,7 @@ class ManifestPrimaryKeyError(Exception):
         return (
             f"{self.message}; "
             f"Table Name: {self.table_name}; "
+            f"Dataset ID: {self.dataset_id}; "
             f"Primary Key: {self.primary_key}; "
             f"Columns: [{','.join(self.columns)}]"
         )
@@ -120,7 +125,10 @@ class RDBUpdater:
 
         if table_schema.primary_key not in list(manifest_table.columns):
             raise ManifestPrimaryKeyError(
-                table_name, table_schema.primary_key, list(manifest_table.columns)
+                table_name,
+                dataset_id,
+                table_schema.primary_key,
+                list(manifest_table.columns),
             )
 
         normalized_table = self._normalize_table(manifest_table, table_schema)

--- a/schematic_db/rdb_updater/rdb_updater.py
+++ b/schematic_db/rdb_updater/rdb_updater.py
@@ -1,7 +1,9 @@
 """RDBUpdater"""
 import warnings
+import pandas as pd
 from schematic_db.rdb.rdb import RelationalDatabase, UpsertDatabaseError
 from schematic_db.manifest_store.manifest_store import ManifestStore
+from schematic_db.db_schema.db_schema import TableSchema
 
 
 class NoManifestWarning(Warning):
@@ -35,6 +37,31 @@ class UpsertError(Exception):
             f"{self.message}; "
             f"Table Name: {self.table_name}; "
             f"Dataset ID: {self.dataset_id}"
+        )
+
+
+class ManifestPrimaryKeyError(Exception):
+    """Raised when a manifest is missing its primary key"""
+
+    def __init__(self, table_name: str, primary_key: str, columns: list[str]) -> None:
+        """
+        Args:
+            table_name (str): The name of the table the upsert occurred in
+            primary_key (str): The dataset id of the manifest that was being upserted
+            columns (list[str]): The columns in the manifest
+        """
+        self.message = "Manifest is missing its primary key"
+        self.table_name = table_name
+        self.primary_key = primary_key
+        self.columns = columns
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return (
+            f"{self.message}; "
+            f"Table Name: {self.table_name}; "
+            f"Primary Key: {self.primary_key}; "
+            f"Columns: [{','.join(self.columns)}]"
         )
 
 
@@ -85,20 +112,42 @@ class RDBUpdater:
             dataset_id (str): The id of the dataset
 
         Raises:
+            ManifestPrimaryKeyError: Raised when the manifest table is missing its primary key
             UpsertError: Raised when there is an UpsertDatabaseError caught
         """
         table_schema = self.rdb.get_table_schema(table_name)
-        manifest_table = self.manifest_store.get_manifest(dataset_id)
+        manifest_table: pd.DataFrame = self.manifest_store.get_manifest(dataset_id)
 
-        # normalize table
-        table_columns = set(table_schema.get_column_names())
-        manifest_columns = set(manifest_table.columns)
-        columns = list(table_columns.intersection(manifest_columns))
-        manifest_table = manifest_table[columns]
-        manifest_table = manifest_table.drop_duplicates(subset=table_schema.primary_key)
-        manifest_table.reset_index(inplace=True, drop=True)
+        if table_schema.primary_key not in list(manifest_table.columns):
+            raise ManifestPrimaryKeyError(
+                table_name, table_schema.primary_key, list(manifest_table.columns)
+            )
+
+        normalized_table = self._normalize_table(manifest_table, table_schema)
 
         try:
-            self.rdb.upsert_table_rows(table_name, manifest_table)
+            self.rdb.upsert_table_rows(table_name, normalized_table)
         except UpsertDatabaseError as exc:
             raise UpsertError(table_name, dataset_id) from exc
+
+    def _normalize_table(
+        self, table: pd.DataFrame, table_schema: TableSchema
+    ) -> pd.DataFrame:
+        """
+        Gets the table ready for upsert by selecting only needed columns and removing
+         duplicate entries
+
+        Args:
+            table (pd.DataFrame): The table to normalize
+            table_schema (TableSchema):The schema of the table
+
+        Returns:
+            pd.DataFrame: A normalized table
+        """
+        table_columns = set(table_schema.get_column_names())
+        manifest_columns = set(table.columns)
+        columns = list(table_columns.intersection(manifest_columns))
+        table = table[columns]
+        table = table.drop_duplicates(subset=table_schema.primary_key)
+        table.reset_index(inplace=True, drop=True)
+        return table


### PR DESCRIPTION
fixes [fds-351](https://sagebionetworks.jira.com/browse/FDS-351)

When a manifest is missing its primary key, pandas raises a very unhelpful exception during normalization. 

This PR:

1. Adds a section to catch when manifests are missing their primary key
2. Adds an exception for missing primary keys
3. Moves normalization to its own method