### PR TITLE
Feature fds 138 396 new endpoint param names

### DIFF
--- a/schematic_db/api_utils/api_utils.py
+++ b/schematic_db/api_utils/api_utils.py
@@ -356,25 +356,19 @@ def get_project_manifests(
     return ManifestMetadataList(response.json())
 
 
-def get_manifest(
-    access_token: str, dataset_id: str, asset_view: str
-) -> pandas.DataFrame:
+def download_manifest(access_token: str, manifest_id: str) -> pandas.DataFrame:
     """Downloads a manifest as a pd.dataframe
 
     Args:
         access_token (str): Access token
-        dataset_id (str): The id of the dataset the manifest part of
-        asset_view (str): The id of the view listing all project data assets. For example,
-            for Synapse this would be the Synapse ID of the fileview listing all
-            data assets for a given project.(i.e. master_fileview in config.yml)
+        manifest_id (str): The synapse id of the manifest
 
     Returns:
         pd.DataFrame: The manifest in dataframe form
     """
     params = {
         "access_token": access_token,
-        "dataset_id": dataset_id,
-        "asset_view": asset_view,
+        "manifest_id": manifest_id,
         "as_json": True,
     }
     response = create_schematic_api_response("manifest/download", params, timeout=600)

--- a/schematic_db/manifest_store/manifest_store.py
+++ b/schematic_db/manifest_store/manifest_store.py
@@ -6,7 +6,7 @@ from pydantic.dataclasses import dataclass
 from pydantic import validator
 import validators
 import pandas as pd
-from schematic_db.api_utils.api_utils import get_project_manifests, get_manifest
+from schematic_db.api_utils.api_utils import get_project_manifests, download_manifest
 from schematic_db.schema_graph.schema_graph import SchemaGraph
 
 
@@ -137,29 +137,25 @@ class ManifestStore:
             asset_view=self.synapse_asset_view_id,
         )
 
-    def get_dataset_ids(self, name: str) -> list[str]:
-        """Gets the dataset ids for a table(component)
+    def get_manifest_ids(self, name: str) -> list[str]:
+        """Gets the manifest ids for a table(component)
 
         Args:
             name (str): The name of the table
 
         Returns:
-            list[str]: The dataset ids for the table
+            list[str]: The manifest ids for the table
         """
-        return self.manifest_metadata.get_dataset_ids_for_component(name)
+        return self.manifest_metadata.get_manifest_ids_for_component(name)
 
-    def get_manifest(self, dataset_id: str) -> pd.DataFrame:
-        """Gets the manifest associated with the dataset id
+    def download_manifest(self, manifest_id: str) -> pd.DataFrame:
+        """Downloads the manifest
 
         Args:
-            dataset_id (str): The synapse id of the dataset
+            manifest_id (str): The synapse id of the manifest
 
         Returns:
             pd.DataFrame: The manifest in dataframe form
         """
-        manifest = get_manifest(
-            self.synapse_input_token,
-            dataset_id,
-            self.synapse_asset_view_id,
-        )
+        manifest = download_manifest(self.synapse_input_token, manifest_id)
         return manifest

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -12,7 +12,7 @@ from schematic_db.api_utils.api_utils import (
     get_property_label_from_display_name,
     get_graph_by_edge_type,
     get_project_manifests,
-    get_manifest,
+    download_manifest,
     is_node_required,
     get_node_validation_rules,
     SchematicAPIError,
@@ -164,8 +164,7 @@ class TestAPIUtilHelpers:
                 endpoint_path="manifest/download",
                 params={
                     "access_token": secrets_dict["synapse"]["auth_token"],
-                    "dataset_id": "syn47996410",
-                    "asset_view": test_synapse_asset_view_id,
+                    "manifest_id": "syn47996491",
                     "as_json": True,
                 },
                 timeout=1,
@@ -227,14 +226,11 @@ class TestAPIUtils:
         )
         assert len(manifest_metadata.metadata_list) == 5
 
-    def test_get_manifest(
-        self, secrets_dict: dict, test_synapse_asset_view_id: str
-    ) -> None:
-        "Testing for get_manifest"
-        manifest = get_manifest(
+    def test_download_manifest(self, secrets_dict: dict) -> None:
+        "Testing for download_manifest"
+        manifest = download_manifest(
             secrets_dict["synapse"]["auth_token"],
-            "syn47996410",
-            test_synapse_asset_view_id,
+            "syn47996491",
         )
         assert isinstance(manifest, pd.DataFrame)
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -132,7 +132,6 @@ class TestAPIUtilHelpers:
         self,
         test_schema_json_url: str,
         secrets_dict: dict,
-        test_synapse_asset_view_id: str,
     ) -> None:
         """Testing for create_schematic_api_response"""
         response = create_schematic_api_response(

--- a/tests/test_manifest_store.py
+++ b/tests/test_manifest_store.py
@@ -14,15 +14,15 @@ class TestSchema:
         for item in obj.manifest_metadata.metadata_list:
             assert isinstance(item, ManifestMetadata)
 
-    def test_get_dataset_ids(self, manifest_store: ManifestStore) -> None:
-        """Testing for Schema.get_get_dataset_ids()"""
+    def test_get_manifest_ids(self, manifest_store: ManifestStore) -> None:
+        """Testing for Schema.get_get_manifest_ids"""
         obj = manifest_store
-        assert obj.get_dataset_ids("Patient") == ["syn47994831", "syn47996086"]
+        assert obj.get_manifest_ids("Patient") == ["syn47996020", "syn47996172"]
 
-    def test_get_manifest(self, manifest_store: ManifestStore) -> None:
-        """Testing for Schema.get_manifest()"""
+    def test_download_manifest(self, manifest_store: ManifestStore) -> None:
+        """Testing for Schema.download_manifest"""
         obj = manifest_store
-        manifest = obj.get_manifest("syn47994831")
+        manifest = obj.download_manifest("syn47996020")
         assert sorted(list(manifest.columns)) == sorted(
             [
                 "patientId",


### PR DESCRIPTION
fixes [fds-396](https://sagebionetworks.jira.com/browse/FDS-396)
fixes [fds-138](https://sagebionetworks.jira.com/browse/FDS-138)

This PR addresses the changes to the schematic API made [here.](https://github.com/Sage-Bionetworks/schematic/pull/1142):
- Parameter name `input_token` was changed to `access_token` in the latest develop version of schematic. 
- The `get_manifest` function was renamed to `download_manifest` to be more in line with the endpoint name
- The `download/manifest` endpoint now uses `manifest_id` instead of `dataset_id`