### PR TITLE
update pypi to use token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish schematic_db to PYPI
 on:
   push:
     branches:
-      - main
+      - develop
 
 jobs:
   test:
@@ -23,8 +23,7 @@ jobs:
 
       - name: Publish package to Pypi
         env:
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           poetry build
-          poetry publish --username $PYPI_USERNAME --password $PYPI_PASSWORD
+          poetry publish -u $PYPI_TOKEN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "schematic_db"
-version = "0.0.37"
+version = "0.0.38"
 description = ""
 authors = ["andrewelamb <andrewelamb@gmail.com>"]
 


### PR DESCRIPTION
- fixes [fds-1535](https://sagebionetworks.jira.com/browse/FDS-1535)
- pypi publish now uses pypi token