### PR TITLE
Fds 1878

### DIFF
--- a/schematic_db/rdb_updater/rdb_updater.py
+++ b/schematic_db/rdb_updater/rdb_updater.py
@@ -110,15 +110,22 @@ class RDBUpdater:
         self.rdb = rdb
         self.manifest_store = manifest_store
 
-    def update_database(self, method: UpdateMethod = "upsert") -> None:
+    def update_database(
+        self, method: UpdateMethod = "upsert", table_names: list[str] | None = None
+    ) -> None:
         """Updates all tables in database
 
         Args:
             method (UpdateMethod): The method used to update each table. Defaults to "upsert".
+            table_names (list[str] | None): If not None, only these tables will be updated
         """
         logging.info("Updating database")
-        table_names = self.manifest_store.create_sorted_table_name_list()
-        for name in table_names:
+        tables_to_update = self.manifest_store.create_sorted_table_name_list()
+        if table_names is not None:
+            tables_to_update = [
+                table for table in tables_to_update if table in table_names
+            ]
+        for name in tables_to_update:
             self.update_table(name, method=method)
         logging.info("Database updated")
 

--- a/tests/test_z_integration.py
+++ b/tests/test_z_integration.py
@@ -235,3 +235,30 @@ class TestIntegration2:
         for name in test_schema_table_names:
             table = rdb_updater.rdb.query_table(name)
             assert len(table.index) > 0
+
+
+class TestIntegration3:
+    """Integration tests with upserts only update one table"""
+
+    def test_mysql(  # pylint: disable=too-many-arguments
+        self,
+        rdb_builder_mysql: RDBBuilder,
+        rdb_updater_mysql: RDBUpdater,
+        test_schema_table_names: list[str],
+    ) -> None:
+        """Creates the test database in MySQL"""
+        rdb_builder = rdb_builder_mysql
+        assert rdb_builder.rdb.get_table_names() == []
+        rdb_builder.build_database()
+        assert rdb_builder.rdb.get_table_names() == test_schema_table_names
+
+
+        rdb_updater = rdb_updater_mysql
+        rdb_updater.update_database(table_names=["Patient"])
+
+        for name in test_schema_table_names:
+            table = rdb_updater.rdb.query_table(name)
+            if name == "Patient":
+                assert len(table.index) > 0
+            else:
+                assert len(table.index) == 0

--- a/tests/test_z_integration.py
+++ b/tests/test_z_integration.py
@@ -237,7 +237,7 @@ class TestIntegration2:
             assert len(table.index) > 0
 
 
-class TestIntegration3:
+class TestIntegration3: # pylint: disable=too-few-public-methods
     """Integration tests with upserts only update one table"""
 
     def test_mysql(  # pylint: disable=too-many-arguments
@@ -251,7 +251,6 @@ class TestIntegration3:
         assert rdb_builder.rdb.get_table_names() == []
         rdb_builder.build_database()
         assert rdb_builder.rdb.get_table_names() == test_schema_table_names
-
 
         rdb_updater = rdb_updater_mysql
         rdb_updater.update_database(table_names=["Patient"])

--- a/tests/test_z_integration.py
+++ b/tests/test_z_integration.py
@@ -237,7 +237,7 @@ class TestIntegration2:
             assert len(table.index) > 0
 
 
-class TestIntegration3: # pylint: disable=too-few-public-methods
+class TestIntegration3:  # pylint: disable=too-few-public-methods
     """Integration tests with upserts only update one table"""
 
     def test_mysql(  # pylint: disable=too-many-arguments


### PR DESCRIPTION
- Fixes [FDS-1878]
- Adds `table_names` parameter to `update_database` method. If used only tables in the given list will be updated.
- `method` parameter changed to 'update_method` and is now a literal.

[FDS-1878]: https://sagebionetworks.jira.com/browse/FDS-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ