### PR TITLE
Fds 2274

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,60 @@ Note: This is a cascading delete. Any rows that reference rows in the dataframe 
 Note: This is also recursive. Rows in tables that reference rows in tables that reference the rows in the dataframe and so on, will also be deleted.
 
 
+#### Configuring your database schema
+
+In general Schematic DB will use your data model to determine the database schema. If you want to change that behavior you can use a [DatabaseConfig](https://github.com/Sage-Bionetworks/schematic_db/blob/main/schema/database_config.py/) object to do this.
+
+Create the object like
+```python
+
+from schematic_db.schema import Schema, SchemaConfig
+from schematic_db.database_config import DatabaseConfig
+
+data = [
+    {
+        "name": "object1",
+        "primary_key": "att1",
+        "foreign_keys": [
+            {
+                "column_name": "att2",
+                "foreign_table_name": "object2",
+                "foreign_column_name": "att1",
+            },
+            {
+                "column_name": "att3",
+                "foreign_table_name": "object3",
+                "foreign_column_name": "att1",
+            },
+        ],
+        "columns": [
+            {
+                "name": "att2",
+                "datatype": "str",
+                "required": True,
+                "index": True,
+            },
+            {
+                "name": "att3",
+                "datatype": "int",
+                "required": False,
+                "index": False,
+            },
+        ],
+    },
+    {"name": "object2", "primary_key": "att1"},
+    {"name": "object3", "primary_key": "att1"},
+]
+database_config = DatabaseConfig(data)
+
+config = SchemaConfig(
+        schema_url = "https://raw.githubusercontent.com/Sage-Bionetworks/Schematic-DB-Test-Schemas/main/test_schema.jsonld"
+    )
+schema = Schema(config=config, database_config=database_config)
+
+```
+
+
 ## Local Development
 
 ### Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "schematic_db"
-version = "0.1.5"
+version = "0.1.6"
 description = ""
 authors = ["andrewelamb <andrewelamb@gmail.com>"]
 

--- a/schematic_db/db_schema/db_schema.py
+++ b/schematic_db/db_schema/db_schema.py
@@ -12,13 +12,29 @@ from schematic_db.utils.validators import string_is_not_empty
 
 
 class ColumnDatatype(Enum):
-    """A generic datatype that should be supported by all database types."""
+    """
+    Either A generic datatype that should be supported by all database types,
+    or a type specific to a certian type of database
+    """
 
+    # generic datatypes usable by any database
     TEXT = "text"
     DATE = "date"
     INT = "int"
     FLOAT = "float"
     BOOLEAN = "boolean"
+    # Synapse specific datatypes
+    SYNAPSE_STRING = "synapse_string"
+    SYNAPSE_FILE_HANDLE_ID = "synapse_file_handle_id"
+    SYNAPSE_ENTITY_ID = "synapse_entity_id"
+    SYNAPSE_LINK = "synapse_link"
+    SYNAPSE_USER_ID = "synapse_user_id"
+    SYNAPSE_STRING_LIST = "synapse_string_list"
+    SYNAPSE_DATE_LIST = "synapse_date_list"
+    SYNAPSE_INT_LIST = "synapse_int_list"
+    SYNAPSE_BOOLEAN_LIST = "synapse_boolean_list"
+    SYNAPSE_ENTITY_ID_LIST = "synapse_entity_id_list"
+    SYNAPSE_USER_ID_LIST = "synapse_user_id_list"
 
 
 @dataclass()
@@ -29,7 +45,8 @@ class ColumnSchema:
     datatype: ColumnDatatype
     required: bool = False
     index: bool = False
-
+    string_size_max: int | None = None
+    list_length_max: int | None = None
     _validate_name = field_validator("name")(string_is_not_empty)
 
 

--- a/schematic_db/schema/database_config.py
+++ b/schematic_db/schema/database_config.py
@@ -9,12 +9,24 @@ from schematic_db.db_schema.db_schema import (
     ColumnDatatype,
 )
 
-
+# used to translate types from the Schematic API or config to the geneirc ENUM
 DATATYPES = {
     "str": ColumnDatatype.TEXT,
     "float": ColumnDatatype.FLOAT,
     "int": ColumnDatatype.INT,
     "date": ColumnDatatype.DATE,
+    "boolean": ColumnDatatype.BOOLEAN,
+    "synapse_string": ColumnDatatype.SYNAPSE_STRING,
+    "synapse_file_handle_id": ColumnDatatype.SYNAPSE_FILE_HANDLE_ID,
+    "synapse_entity_id": ColumnDatatype.SYNAPSE_ENTITY_ID,
+    "synapse_link": ColumnDatatype.SYNAPSE_LINK,
+    "synapse_user_id": ColumnDatatype.SYNAPSE_USER_ID,
+    "synapse_string_list": ColumnDatatype.SYNAPSE_STRING_LIST,
+    "synapse_date_list": ColumnDatatype.SYNAPSE_DATE_LIST,
+    "synapse_int_list": ColumnDatatype.SYNAPSE_INT_LIST,
+    "synapse_boolean_list": ColumnDatatype.SYNAPSE_BOOLEAN_LIST,
+    "synapse_entity_id_list": ColumnDatatype.SYNAPSE_ENTITY_ID_LIST,
+    "synapse_user_id_list": ColumnDatatype.SYNAPSE_USER_ID_LIST,
 }
 
 
@@ -27,12 +39,18 @@ class ColumnConfig:
         datatype (ColumnDatatype | None): The data type of the column
         required: (bool | None): If the columne is required
         index: (bool | None): If the column should be indexed
+        string_size_max: (int | None) Max size for string columns if used
+        list_length_max: (int | None) Max size for list column ength if used
+
+
     """
 
     name: str
     datatype: ColumnDatatype | None = None
     required: bool | None = None
     index: bool | None = None
+    string_size_max: int | None = None
+    list_length_max: int | None = None
 
 
 class TableConfig:  # pylint: disable=too-few-public-methods

--- a/schematic_db/schema/database_config.py
+++ b/schematic_db/schema/database_config.py
@@ -3,10 +3,9 @@ A config for database specific items
 """
 
 from typing import Any, Optional
-from deprecation import deprecated
+from pydantic.dataclasses import dataclass
 from schematic_db.db_schema.db_schema import (
     ForeignKeySchema,
-    ColumnSchema,
     ColumnDatatype,
 )
 
@@ -19,14 +18,24 @@ DATATYPES = {
 }
 
 
-@deprecated(
-    deprecated_in="0.0.27",
-    details=(
-        "Functionality will be accomplished with future Schematic API calls. "
-        "This will be sunsetted in ~1.0 .",
-    ),
-)
-class DatabaseTableConfig:  # pylint: disable=too-few-public-methods
+@dataclass()
+class ColumnConfig:
+    """
+    A config for a table column (attribute).
+    Properties:
+        name (str): The name of the column
+        datatype (ColumnDatatype | None): The data type of the column
+        required: (bool | None): If the columne is required
+        index: (bool | None): If the column should be indexed
+    """
+
+    name: str
+    datatype: ColumnDatatype | None = None
+    required: bool | None = None
+    index: bool | None = None
+
+
+class TableConfig:  # pylint: disable=too-few-public-methods
     """A config for database specific items for one table"""
 
     def __init__(
@@ -56,56 +65,14 @@ class DatabaseTableConfig:  # pylint: disable=too-few-public-methods
             self.columns = None
         else:
             self.columns = [
-                ColumnSchema(
-                    name=column["column_name"],
+                ColumnConfig(
+                    name=column["name"],
                     datatype=DATATYPES[column["datatype"]],
                     required=column["required"],
                     index=column["index"],
                 )
                 for column in columns
             ]
-
-    def _check_column_names(self) -> None:
-        """Checks that column names are not duplicated
-
-        Raises:
-            ValueError: Raised when there are duplicate column names
-        """
-        column_names = self._get_column_names()
-        if column_names is not None:
-            if len(column_names) != len(list(set(column_names))):
-                raise ValueError("There are duplicate column names")
-
-    def _get_column_names(self) -> list[str] | None:
-        """Gets the list of column names in the config
-
-        Returns:
-            list[str]: A list of column names
-        """
-        if self.columns is not None:
-            return [column.name for column in self.columns]
-        return None
-
-    def _check_foreign_key_name(self) -> None:
-        """Checks that foreign keys are not duplicated
-
-        Raises:
-            ValueError: Raised when there are duplicate foreign keys
-        """
-        foreign_keys_names = self._get_foreign_key_names()
-        if foreign_keys_names is not None:
-            if len(foreign_keys_names) != len(list(set(foreign_keys_names))):
-                raise ValueError("There are duplicate column names")
-
-    def _get_foreign_key_names(self) -> list[str] | None:
-        """Gets the list of foreign key names in the config
-
-        Returns:
-            list[str]: A list of foreign key names
-        """
-        if self.foreign_keys is not None:
-            return [key.name for key in self.foreign_keys]
-        return None
 
 
 class DatabaseConfig:
@@ -115,9 +82,7 @@ class DatabaseConfig:
         """
         Init
         """
-        self.tables: list[DatabaseTableConfig] = [
-            DatabaseTableConfig(**table) for table in tables
-        ]
+        self.tables: list[TableConfig] = [TableConfig(**table) for table in tables]
         self._check_table_names()
 
     def get_primary_key(self, table_name: str) -> str | None:
@@ -144,19 +109,19 @@ class DatabaseConfig:
         table = self._get_table_by_name(table_name)
         return None if table is None else table.foreign_keys
 
-    def get_columns(self, table_name: str) -> list[ColumnSchema] | None:
+    def get_columns(self, table_name: str) -> list[ColumnConfig] | None:
         """Gets the columns for an table
 
         Args:
             table_name (str): The name of the table
 
         Returns:
-            Optional[list[ColumnSchema]]: The list of columns
+            list[ColumnConfig] | None: The list of columns or None if the table doesn't exist
         """
         table = self._get_table_by_name(table_name)
         return None if table is None else table.columns
 
-    def get_column(self, table_name: str, column_name: str) -> ColumnSchema | None:
+    def get_column(self, table_name: str, column_name: str) -> ColumnConfig | None:
         """Gets a column for a table
 
         Args:
@@ -174,14 +139,14 @@ class DatabaseConfig:
             return None
         return columns[0]
 
-    def _get_table_by_name(self, table_name: str) -> Optional[DatabaseTableConfig]:
+    def _get_table_by_name(self, table_name: str) -> Optional[TableConfig]:
         """Gets the config for the table if it exists
 
         Args:
             table_name (str): The name of the table
 
         Returns:
-            Optional[DatabaseTableConfig]: The config for the table if it exists
+            Optional[TableConfig]: The config for the table if it exists
         """
         tables = [table for table in self.tables if table.name == table_name]
         if len(tables) == 0:

--- a/schematic_db/schema/schema.py
+++ b/schematic_db/schema/schema.py
@@ -217,15 +217,27 @@ class Schema:
             ColumnSchema: The schema for the column
         """
         column = self.database_config.get_column(table_name, column_name)
-        # Use column config if provided
-        if column is not None:
-            return column
-        # Create column config if not provided
+
+        # first the config is checked for datatype
+        # and if not there, gotten from schematic
+        datatype = (
+            column.datatype
+            if column and column.datatype is not None
+            else self._get_column_datatype(column_name, table_name)
+        )
+        # first the config is checked for if the column is required,
+        # and if not there, gotten from schematic
+        required = (
+            column.required
+            if column and column.required is not None
+            else self._is_column_required(column_name, table_name)
+        )
+        # first the config is checked for if the column should be indexed,
+        # and if not there, defaults to false
+        index = column.index if column and column.index is not None else False
+
         return ColumnSchema(
-            name=column_name,
-            datatype=self._get_column_datatype(column_name, table_name),
-            required=self._is_column_required(column_name, table_name),
-            index=False,
+            name=column_name, datatype=datatype, required=required, index=index
         )
 
     def _is_column_required(self, column_name: str, table_name: str) -> bool:

--- a/schematic_db/schema/schema.py
+++ b/schematic_db/schema/schema.py
@@ -235,9 +235,17 @@ class Schema:
         # first the config is checked for if the column should be indexed,
         # and if not there, defaults to false
         index = column.index if column and column.index is not None else False
+        # check if config exists, and if not default to None for both max values
+        string_size_max = column.string_size_max if column else None
+        list_length_max = column.list_length_max if column else None
 
         return ColumnSchema(
-            name=column_name, datatype=datatype, required=required, index=index
+            name=column_name,
+            datatype=datatype,
+            required=required,
+            index=index,
+            string_size_max=string_size_max,
+            list_length_max=list_length_max,
         )
 
     def _is_column_required(self, column_name: str, table_name: str) -> bool:

--- a/schematic_db/synapse/synapse.py
+++ b/schematic_db/synapse/synapse.py
@@ -96,14 +96,14 @@ class Synapse:  # pylint: disable=too-many-public-methods
         Returns:
             list[str]: A list of table names
         """
-        tables = self._get_tables()
+        tables = self._get_table_data()
         return [table["name"] for table in tables]
 
-    def _get_tables(self) -> list[synapseclient.Table]:
+    def _get_table_data(self) -> list[dict[str, Any]]:
         """Gets the list of Synapse table entities for the project
 
         Returns:
-            list[synapseclient.Table]: A list of all Synapse table entities
+            list[dict[str, Any]]: A list of all Synapse tables as dicts
         """
         project = self.syn.get(self.project_id)
         return list(self.syn.getChildren(project, includeTypes=["table"]))
@@ -135,7 +135,7 @@ class Synapse:  # pylint: disable=too-many-public-methods
         Returns:
             str: A synapse id
         """
-        tables = self._get_tables()
+        tables = self._get_table_data()
         matching_tables = [table for table in tables if table["name"] == table_name]
         if len(matching_tables) == 0:
             raise SynapseTableNameError("No matching tables with name:", table_name)
@@ -154,7 +154,7 @@ class Synapse:  # pylint: disable=too-many-public-methods
         Returns:
             str: The name of the table with the synapse id
         """
-        tables = self._get_tables()
+        tables = self._get_table_data()
         return [table["name"] for table in tables if table["id"] == synapse_id][0]
 
     def query_table(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,7 +234,7 @@ def fixture_test_schema2(test_schema_csv_url: str) -> Generator[Schema, None, No
                 "primary_key": "id",
                 "columns": [
                     {
-                        "column_name": "sex",
+                        "name": "sex",
                         "datatype": "str",
                         "required": True,
                         "index": True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -325,19 +325,41 @@ def fixture_rdb_queryer_mysql(
     yield obj
 
 
-@pytest.fixture(scope="session")
-def table_one() -> Generator[pd.DataFrame, None, None]:
+@pytest.fixture(scope="session", name="table_one")
+def fixture_table_one() -> Generator[pd.DataFrame, None, None]:
     """
     Yields a pd.Dataframe.
     """
     dataframe = pd.DataFrame(
         {
             "pk_one_col": ["key1", "key2", "key3"],
-            "string_one_col": ["a", "b", np.nan],
+            "text_one_col": ["a", "b", np.nan],
             "int_one_col": [1, pd.NA, 3],
             "double_one_col": [1.1, 2.2, np.nan],
             "date_one_col": [datetime(2022, 8, 2), np.nan, datetime(2022, 8, 2)],
             "bool_one_col": [pd.NA, True, False],
+        }
+    )
+    dataframe = dataframe.astype({"int_one_col": "Int64", "bool_one_col": "boolean"})
+    dataframe["date_one_col"] = pd.to_datetime(dataframe["date_one_col"]).dt.date
+    yield dataframe
+
+
+@pytest.fixture(scope="session", name="synapse_table_one")
+def fixture_synapse_table_one() -> Generator[pd.DataFrame, None, None]:
+    """
+    Yields a pd.Dataframe.
+    """
+    dataframe = pd.DataFrame(
+        {
+            "pk_one_col": ["key1", "key2", "key3"],
+            "text_one_col": ["a", "b", np.nan],
+            "int_one_col": [1, pd.NA, 3],
+            "double_one_col": [1.1, 2.2, np.nan],
+            "date_one_col": [datetime(2022, 8, 2), np.nan, datetime(2022, 8, 2)],
+            "bool_one_col": [pd.NA, True, False],
+            "string_one_col": ["a", "b", np.nan],
+            "string_list_one_col": ["[a,b,c]", "[d,f]", np.nan],
         }
     )
     dataframe = dataframe.astype({"int_one_col": "Int64", "bool_one_col": "boolean"})
@@ -360,7 +382,7 @@ def fixture_table_one_schema() -> Generator[TableSchema, None, None]:
                 index=True,
             ),
             ColumnSchema(
-                name="string_one_col",
+                name="text_one_col",
                 datatype=ColumnDatatype.TEXT,
                 required=False,
                 index=True,
@@ -384,16 +406,82 @@ def fixture_table_one_schema() -> Generator[TableSchema, None, None]:
     yield schema
 
 
+@pytest.fixture(scope="session", name="synapse_table_one_schema")
+def fixture_synapse_table_one_schema() -> Generator[TableSchema, None, None]:
+    """
+    Yields a TableSchema object with one primary and no foreign keys
+    """
+    schema = TableSchema(
+        name="table_one",
+        columns=[
+            ColumnSchema(
+                name="pk_one_col",
+                datatype=ColumnDatatype.TEXT,
+                required=True,
+                index=True,
+            ),
+            ColumnSchema(
+                name="text_one_col",
+                datatype=ColumnDatatype.TEXT,
+                required=False,
+                index=True,
+            ),
+            ColumnSchema(
+                name="int_one_col", datatype=ColumnDatatype.INT, required=False
+            ),
+            ColumnSchema(
+                name="double_one_col", datatype=ColumnDatatype.FLOAT, required=False
+            ),
+            ColumnSchema(
+                name="date_one_col", datatype=ColumnDatatype.DATE, required=False
+            ),
+            ColumnSchema(
+                name="bool_one_col", datatype=ColumnDatatype.BOOLEAN, required=False
+            ),
+            ColumnSchema(
+                name="string_one_col",
+                datatype=ColumnDatatype.SYNAPSE_STRING,
+                required=False,
+            ),
+            ColumnSchema(
+                name="string_list_one_col",
+                datatype=ColumnDatatype.SYNAPSE_STRING_LIST,
+                required=False,
+                string_size_max=49,
+                list_length_max=99,
+            ),
+        ],
+        primary_key="pk_one_col",
+        foreign_keys=[],
+    )
+    yield schema
+
+
 @pytest.fixture(name="table_one_columns", scope="session")
 def fixture_table_one_columns() -> Generator[list[sc.Column], None, None]:
     """Yields a list of synapse columns for table one"""
     yield [
         sc.Column(name="pk_one_col", columnType="LARGETEXT"),
-        sc.Column(name="string_one_col", columnType="LARGETEXT"),
+        sc.Column(name="text_one_col", columnType="LARGETEXT"),
         sc.Column(name="int_one_col", columnType="INTEGER"),
         sc.Column(name="double_one_col", columnType="DOUBLE"),
         sc.Column(name="date_one_col", columnType="DATE"),
         sc.Column(name="bool_one_col", columnType="BOOLEAN"),
+    ]
+
+
+@pytest.fixture(name="synapse_table_one_columns", scope="session")
+def fixture_synapse_table_one_columns() -> Generator[list[sc.Column], None, None]:
+    """Yields a list of synapse columns for table one"""
+    yield [
+        sc.Column(name="pk_one_col", columnType="LARGETEXT"),
+        sc.Column(name="text_one_col", columnType="LARGETEXT"),
+        sc.Column(name="int_one_col", columnType="INTEGER"),
+        sc.Column(name="double_one_col", columnType="DOUBLE"),
+        sc.Column(name="date_one_col", columnType="DATE"),
+        sc.Column(name="bool_one_col", columnType="BOOLEAN"),
+        sc.Column(name="string_one_col", columnType="STRING"),
+        sc.Column(name="string_list_one_col", columnType="STRING_LIST"),
     ]
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -176,6 +176,26 @@ class TestDatabaseConfig:
         assert obj.get_columns("object2") is None
         assert obj.get_columns("object3") is None
 
+    def test_max_type_values(self) -> None:
+        """Testing for string_size_max and list_length_max"""
+        data = [
+            {
+                "name": "object1",
+                "columns": [
+                    {
+                        "name": "att",
+                        "datatype": "synapse_string_list",
+                        "required": True,
+                        "index": True,
+                        "string_size_max": 1,
+                        "list_length_max": 1,
+                    },
+                ],
+            },
+        ]
+        obj = DatabaseConfig(data)
+        assert obj
+
 
 class TestSchema:
     """Testing for Schema"""

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -244,10 +244,10 @@ class TestSQLUpdateRows:
             pd.testing.assert_frame_equal(query_result1, query_result2)
 
             table_one_copy = table_one.copy()
-            table_one_copy["string_one_col"] = ["a", "b", "c"]
+            table_one_copy["text_one_col"] = ["a", "b", "c"]
             obj.upsert_table_rows("table_one", table_one_copy)
             query_result3 = obj.query_table("table_one")
-            assert query_result3["string_one_col"].values.tolist() == ["a", "b", "c"]
+            assert query_result3["text_one_col"].values.tolist() == ["a", "b", "c"]
 
             obj.drop_table("table_one")
             assert obj.get_table_names() == []
@@ -269,13 +269,13 @@ class TestSQLUpdateRows:
 
             obj.upsert_table_rows("table_one", table_one)
             query_result1 = obj.query_table("table_one")
-            assert query_result1["string_one_col"].values.tolist() == ["a", "b", None]
+            assert query_result1["text_one_col"].values.tolist() == ["a", "b", None]
 
             table_one_copy = table_one.copy()
-            table_one_copy["string_one_col"] = ["a", "b", "c"]
+            table_one_copy["text_one_col"] = ["a", "b", "c"]
             obj.upsert_table_rows("table_one", table_one_copy)
             query_result2 = obj.query_table("table_one")
-            assert query_result2["string_one_col"].values.tolist() == ["a", "b", "c"]
+            assert query_result2["text_one_col"].values.tolist() == ["a", "b", "c"]
 
             obj.drop_table("table_one")
             assert obj.get_table_names() == []

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -8,7 +8,7 @@ from schematic_db.db_schema.db_schema import TableSchema
 from schematic_db.synapse.synapse import Synapse
 
 SYNAPSE_LOGIN_METHOD = "synapseclient.Synapse.login"
-SCHEMATIC_GET_TABLES_METHOD = "schematic_db.synapse.synapse.Synapse._get_tables"
+SCHEMATIC_GET_TABLES_METHOD = "schematic_db.synapse.synapse.Synapse._get_table_data"
 
 
 @pytest.fixture(name="synapse_with_test_table_one", scope="class")
@@ -79,9 +79,7 @@ class TestMockSynapse:
         """Testing for Synapse.get_table_names"""
         tables = [{"name": "table1", "id": "syn1"}, {"name": "table2", "id": "syn2"}]
         mocker.patch(SYNAPSE_LOGIN_METHOD, return_value=None)
-        mocker.patch(
-            "schematic_db.synapse.synapse.Synapse._get_tables", return_value=tables
-        )
+        mocker.patch(SCHEMATIC_GET_TABLES_METHOD, return_value=tables)
         obj = Synapse("", "")
         assert obj.get_table_names() == ["table1", "table2"]
 
@@ -147,13 +145,15 @@ class TestSynapseGetters:
         """Testing for Synapse.get_table_names()"""
         assert synapse_with_test_table_one.get_table_names() == ["test_table_one"]
 
-    def test_get_column_table_names(
+    def test_get_table_column_names(
         self, synapse_with_test_table_one: Synapse, table_one_schema: TableSchema
     ) -> None:
         """Testing for Synapse.get_table_column_names()"""
-        assert sorted(
+        expected_column_names = sorted(table_one_schema.get_column_names())
+        tested_column_names = sorted(
             synapse_with_test_table_one.get_table_column_names("test_table_one")
-        ) == sorted(table_one_schema.get_column_names())
+        )
+        assert tested_column_names == expected_column_names
 
     def test_get_table_id_and_name(self, synapse_with_test_table_one: Synapse) -> None:
         """Testing for Synapse.get_table_id_from_name()"""


### PR DESCRIPTION
- fixes [FDS-2274]
- `DatabaseConfig` class columns are all optinal now
- `DatabaseConfig` class columns include `string_size_max` for synapse string columns
- `DatabaseConfig` class columns include `list_length_max` for synapse list columns

These columns were added (only availble via the `DatabaseConfig` class)

-  "synapse_string"
-  "synapse_file_handle_id"
-  "synapse_entity_id"
-  "synapse_link"
-  "synapse_user_id"
-  "synapse_string_list"
-  "synapse_date_list"
-  "synapse_int_list"
-  "synapse_boolean_list"
-  "synapse_entity_id_list"
-  "synapse_user_id_list"

[FDS-2274]: https://sagebionetworks.jira.com/browse/FDS-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ